### PR TITLE
Update preserve deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@truffle/error": "^0.1.0",
     "@truffle/preserve-fs": "^0.2.7",
     "@truffle/preserve-to-filecoin": "^0.2.9",
     "@truffle/preserve-to-ipfs": "^0.2.8"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
-  "devDependencies": {
-    "truffle": "^5.2.0-preserves.8"
+  "dependencies": {
+    "@truffle/error": "^0.1.0",
+    "@truffle/preserve-fs": "^0.2.7",
+    "@truffle/preserve-to-filecoin": "^0.2.9",
+    "@truffle/preserve-to-ipfs": "^0.2.8"
   }
 }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
 
   plugins: [
+    "@truffle/preserve-fs",
     "@truffle/preserve-to-ipfs",
     "@truffle/preserve-to-filecoin"
   ]


### PR DESCRIPTION
This PR adds the `preserve*` dependencies needed because truffle no longer bundles them.

- `@truffle/preserve-fs`
- `@truffle/preserve-to-ipfs`
- `@truffle/preserve-to-filecoin`